### PR TITLE
Adds missing space after meta in code example

### DIFF
--- a/elements/meta.html
+++ b/elements/meta.html
@@ -37,7 +37,7 @@
   <pre class="code-example">
     <code>
       &lt;html&gt;
-        <strong>&lt;meta</strong>content="author" name="John Smith"<strong>&gt;</strong>
+        <strong>&lt;meta</strong> content="author" name="John Smith"<strong>&gt;</strong>
       &lt;/html&gt;
     </code>
   </pre>


### PR DESCRIPTION
:cactus: 

ready to go
