### PR TITLE
Updates to English base and Spanish translation

### DIFF
--- a/elements/a.html
+++ b/elements/a.html
@@ -8,10 +8,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English base word: <strong>Anchor</strong>
+        English base: <strong>Anchor</strong>
       </div>
       <div class="base-word-line">
-        Spanish word equivalent: <strong>Ancla</strong>
+        Spanish translation/Traducción en Español: <strong>Ancla</strong>
       </div>
     </div>
   </header>

--- a/elements/base.html
+++ b/elements/base.html
@@ -7,10 +7,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong>base</strong>
+        English Base: <strong>base</strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong>base</strong>
+        Spanish translation/Traducción en Español: <strong>base</strong>
       </div>
     </div>
   </header>

--- a/elements/body.html
+++ b/elements/body.html
@@ -8,10 +8,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English base word: <strong>Body</strong>
+        English base: <strong>Body</strong>
       </div>
       <div class="base-word-line">
-        Spanish word equivalent: <strong>Cuerpo</strong>
+        Spanish translation/Traducción en Español: <strong>Cuerpo</strong>
       </div>
     </div>
   </header>

--- a/elements/br.html
+++ b/elements/br.html
@@ -9,10 +9,10 @@
   </h2>
   <div class="base-words">
     <div class="base-word-line">
-      English base word: <strong>(Line) Break</strong>
+      English base: <strong>(Line) Break</strong>
     </div>
     <div class="base-word-line">
-      Spanish word equivalent: <strong>Romper (la Línea); (Representa un Salto de Línea)</strong>
+      Spanish translation/Traducción en Español: <strong>Romper (la Línea); (Representa un Salto de Línea)</strong>
     </div>
   </div>
 </header>

--- a/elements/footer.html
+++ b/elements/footer.html
@@ -8,10 +8,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English base word: <strong>Footer</strong>
+        English base: <strong>Footer</strong>
       </div>
       <div class="base-word-line">
-        Spanish word equivalent: <strong>Pie de P&aacute;inga</strong>
+        Spanish translation/Traducción en Español: <strong>Pie de P&aacute;inga</strong>
       </div>
     </div>
   </header>

--- a/elements/head.html
+++ b/elements/head.html
@@ -3,10 +3,10 @@
     <h2><code>&lt;head&gt;</code></h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong>Head</strong>
+        English Base: <strong>Head</strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong></strong>
+        Spanish translation/Traducción en Español: <strong></strong>
       </div>
     </div>
   </header>

--- a/elements/header.html
+++ b/elements/header.html
@@ -9,10 +9,10 @@
      </h2>
      <div class="base-words">
         <div class="base-word-line">
-           English Base Word: <strong>Header</strong>
+           English Base: <strong>Header</strong>
         </div>
         <div class="base-word-line">
-           Spanish Word Equivalent: <strong>Encabezamiento</strong>
+           Spanish translation/Traducción en Español: <strong>Encabezamiento</strong>
         </div>
      </div>
   </header>

--- a/elements/html.html
+++ b/elements/html.html
@@ -7,10 +7,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong>Hyper Text Markup Language</strong>
+        English Base: <strong>Hyper Text Markup Language</strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong>Lenguaje de Marcas de Hiptertexto</strong>
+        Spanish translation/Traducción en Español: <strong>Lenguaje de Marcas de Hiptertexto</strong>
       </div>
     </div>
   </header>

--- a/elements/link.html
+++ b/elements/link.html
@@ -7,10 +7,10 @@
      </h2>
      <div class="base-words">
         <div class="base-word-line">
-           English Base Word: <strong>Link</strong>
+           English Base: <strong>Link</strong>
         </div>
         <div class="base-word-line">
-           Spanish Word Equivalent: <strong></strong>
+           Spanish translation/Traducción en Español: <strong></strong>
         </div>
      </div>
   </header>

--- a/elements/meta.html
+++ b/elements/meta.html
@@ -7,10 +7,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong>Metadata</strong>
+        English Base: <strong>Metadata</strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong></strong>
+        Spanish translation/Traducción en Español: <strong></strong>
       </div>
     </div>
   </header>

--- a/elements/style.html
+++ b/elements/style.html
@@ -7,10 +7,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong>Style</strong>
+        English Base: <strong>Style</strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong></strong>
+        Spanish translation/Traducción en Español: <strong></strong>
       </div>
     </div>
   </header>

--- a/elements/template.html
+++ b/elements/template.html
@@ -8,10 +8,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong></strong>
+        English Base: <strong></strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong></strong>
+        Spanish translation/Traducción en Español: <strong></strong>
       </div>
     </div>
   </header>

--- a/elements/title.html
+++ b/elements/title.html
@@ -7,10 +7,10 @@
     </h2>
     <div class="base-words">
       <div class="base-word-line">
-        English Base Word: <strong>Title</strong>
+        English Base: <strong>Title</strong>
       </div>
       <div class="base-word-line">
-        Spanish Word Equivalent: <strong>Título</strong>
+        Spanish translation/Traducción en Español: <strong>Título</strong>
       </div>
     </div>
   </header>


### PR DESCRIPTION
:green_book: This is ready to go. - Each definition needed the two titles changed to the same thing on all pages:  English base: and Spanish translation/Traducción en Español:
